### PR TITLE
add worker id to key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ then start the computation we're examining (as before).
 The source is in `src/bin/schedule.rs`. Run with:
 
 ```
-$ cargo run --bin messages -- 4
+$ cargo run --bin schedule -- 4
 ```
 
 Open a browser at http://localhost:9000


### PR DESCRIPTION
This PR adds the worker identifier to the map of start and stop times, so that interleaved starts and stops from different workers are less confusing, and should no longer cause assertion failures.